### PR TITLE
Use ioctl instead of requiring curses

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-clang -Ofast -Wall -Wextra -Werror -pedantic -lcurses term-size.c -o term-size
+clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size

--- a/term-size.c
+++ b/term-size.c
@@ -6,7 +6,7 @@
 #include <sys/ioctl.h> // ioctl()
 
 int main() {
-	int tty_fd = open("/dev/tty", O_RDONLY);
+	int tty_fd = open("/dev/tty", O_EVTONLY | O_NONBLOCK);
 	if (tty_fd == -1) {
 		fprintf(stderr, "Opening `/dev/tty` failed (%d): %s\n", errno, strerror(errno));
 		return 1;

--- a/term-size.c
+++ b/term-size.c
@@ -1,10 +1,9 @@
 #include <stdio.h>
-#include <string.h> // strerror
-#include <errno.h>  // errno
-#include <fcntl.h>  // open(), O_RDONLY
-#include <unistd.h> // close()
-#include <curses.h> // setupterm(), tigetnum()
-#include <term.h>   // ^ Same as above
+#include <string.h>    // strerror
+#include <errno.h>     // errno
+#include <fcntl.h>     // open(), O_RDONLY
+#include <unistd.h>    // close()
+#include <sys/ioctl.h> // ioctl()
 
 int main() {
 	int tty_fd = open("/dev/tty", O_RDONLY);
@@ -13,25 +12,16 @@ int main() {
 		return 1;
 	}
 
-	// Intentionally not handling errors as none of
-	// the documented errors can happen on macOS
-	setupterm("xterm", tty_fd, NULL);
+	struct winsize ws;
+	int result = ioctl(tty_fd, TIOCGWINSZ, &ws);
+	close(tty_fd);
 
-	int cols = tigetnum("cols");
-	if (cols < 0) {
-		fprintf(stderr, "tigetnum(\"cols\") returned error code %d\n", cols);
-		close(tty_fd);
+	if (result == -1) {
+		fprintf(stderr, "Getting size failed (%d): %s\n", errno, strerror(errno));
 		return 1;
 	}
 
-	int rows = tigetnum("lines");
-	if (rows < 0) {
-		fprintf(stderr, "tigetnum(\"lines\") returned error code %d\n", rows);
-		close(tty_fd);
-		return 1;
-	}
-
-	fprintf(stdout, "%d\n%d\n", cols, rows);
+	fprintf(stdout, "%d\n%d\n", ws.ws_col, ws.ws_row);
 	return 0;
 }
 


### PR DESCRIPTION
No need to pull in curses just for the size; just ask the TTY device directly using its [ioctl](http://stackoverflow.com/questions/15807846/ioctl-linux-device-driver).

Faster, cleaner, 100 bytes smaller executable and no dependencies (ioctl is a UNIX thing).

Neat trick with the use of `/dev/tty` - I'll have to remember that.