### PR TITLE
Codesign and harden the binary

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,18 @@
 #!/usr/bin/env sh
 
+set -e
+set -x
+
 clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size
+
+# $SIGN should be the signing identity whose key is available in the keychain,
+# e.g. "Node.js Foundation"
+if [ "X$SIGN" == "X" ]; then
+  echo "No SIGN environment varriable, skipping codesign" >&2
+else
+  codesign \
+    --sign "$SIGN" \
+    --options runtime \
+    --timestamp \
+    term-size
+fi

--- a/build
+++ b/build
@@ -8,7 +8,7 @@ clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size
 # $SIGN should be the signing identity whose key is available in the keychain,
 # e.g. "Node.js Foundation"
 if [ "X$SIGN" == "X" ]; then
-  echo "No SIGN environment varriable, skipping codesign" >&2
+  echo "No SIGN environment variable, skipping codesign" >&2
 else
   codesign \
     --sign "$SIGN" \

--- a/build
+++ b/build
@@ -5,13 +5,13 @@ set -x
 
 clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size
 
-# $SIGN should be the signing identity whose key is available in the keychain,
-# e.g. "Node.js Foundation"
-if [ "X$SIGN" == "X" ]; then
-  echo "No SIGN environment variable, skipping codesign" >&2
+# $CODE_SIGN_IDENTITY should be the signing identity whose key is available in
+# the keychain, e.g. "Node.js Foundation"
+if [[ -n $CODE_SIGN_IDENTITY ]]; then
+  echo "No CODE_SIGN_IDENTITY environment variable, skipping codesign" >&2
 else
   codesign \
-    --sign "$SIGN" \
+    --sign "$CODE_SIGN_IDENTITY" \
     --options runtime \
     --timestamp \
     term-size

--- a/build
+++ b/build
@@ -6,13 +6,13 @@ set -x
 clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size
 
 # $CODE_SIGN_IDENTITY should be the signing identity whose key is available in
-# the keychain, e.g. "Node.js Foundation"
+# the keychain. For example, `Node.js Foundation`.
 if [[ -n $CODE_SIGN_IDENTITY ]]; then
-  echo "No CODE_SIGN_IDENTITY environment variable, skipping codesign" >&2
+	echo "No CODE_SIGN_IDENTITY environment variable, skipping codesigning" >&2
 else
-  codesign \
-    --sign "$CODE_SIGN_IDENTITY" \
-    --options runtime \
-    --timestamp \
-    term-size
+	codesign \
+		--sign "$CODE_SIGN_IDENTITY" \
+		--options runtime \
+		--timestamp \
+		term-size
 fi


### PR DESCRIPTION
Closes #2

Apparently this doesn't need any special entitlements, the hardened `runtime` gives it the access it needs.