### PR TITLE
Output a universal binary

### DIFF
--- a/build
+++ b/build
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 term-size.c -o term-size
+clang -Ofast -Wall -Wextra -Werror -pedantic -std=c99 -arch arm64 -arch x86_64 term-size.c -o term-size
 
 # $CODE_SIGN_IDENTITY should be the signing identity whose key is available in
 # the keychain. For example, `Node.js Foundation`.


### PR DESCRIPTION
it will require macos 11 sdk, but compiled binary can be run on previous versions
(tested at a 2012 intel macmini running catalina, can later test on a mavericks install, just need to dust off some HDDs 😅 )